### PR TITLE
ci+docker: multi-stage Dockerfile + GitHub Actions matrix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,6 @@ data/uploads
 .env.*
 imgs
 docs
-README.md
 .pre-commit-config.yaml
 .gitignore
 .dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,16 +88,39 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Smoke /health
         run: |
+          set +e
           docker run --rm -d --name anpr-ci -p 8000:8000 \
             -e ANPR_PLATE_HMAC_PEPPER="$ANPR_PLATE_HMAC_PEPPER" \
             anpr:ci
-          for i in $(seq 1 30); do
-            if curl -fsS http://localhost:8000/health; then
-              echo " up after ${i}s"; break
+
+          ok=0
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "Up after ${i}s"
+              ok=1
+              break
+            fi
+            if ! docker ps --filter name=anpr-ci --format '{{.Names}}' | grep -q anpr-ci; then
+              echo "Container died:"
+              docker logs anpr-ci 2>&1 | tail -100
+              exit 1
             fi
             sleep 1
           done
-          curl -fsS http://localhost:8000/health
-          curl -fsS http://localhost:8000/version
-          docker logs anpr-ci | tail -50
-          docker stop anpr-ci
+
+          echo "--- container logs ---"
+          docker logs anpr-ci 2>&1 | tail -100
+
+          if [ "$ok" -ne 1 ]; then
+            echo "ERROR: /health never responded"
+            docker stop anpr-ci >/dev/null 2>&1
+            exit 1
+          fi
+
+          echo "--- /health ---"
+          curl -fsS http://localhost:8000/health || exit 1
+          echo
+          echo "--- /version ---"
+          curl -fsS http://localhost:8000/version || exit 1
+          echo
+          docker stop anpr-ci >/dev/null 2>&1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Smoke /health
         run: |
           set +e
-          docker run --rm -d --name anpr-ci -p 8000:8000 \
+          docker run -d --name anpr-ci -p 8000:8000 \
             -e ANPR_PLATE_HMAC_PEPPER="$ANPR_PLATE_HMAC_PEPPER" \
             anpr:ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ANPR_PLATE_HMAC_PEPPER: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install dev deps
+        run: uv sync --group dev
+      - name: ruff check
+        run: uv run ruff check src tests scripts
+      - name: ruff format --check
+        run: uv run ruff format --check src tests scripts
+
+  type:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install all deps
+        run: uv sync --all-extras --group dev
+      - name: pyright
+        run: uv run pyright src tests
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install all deps
+        run: uv sync --all-extras --group dev
+      - name: pytest
+        run: |
+          uv run pytest \
+            --ignore=tests/integration/test_pipeline_real.py \
+            --cov=anpr \
+            --cov-report=xml \
+            --cov-report=term-missing
+      - name: Upload coverage
+        if: matrix.python == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        continue-on-error: true
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: [lint, type, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: anpr:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke /health
+        run: |
+          docker run --rm -d --name anpr-ci -p 8000:8000 \
+            -e ANPR_PLATE_HMAC_PEPPER="$ANPR_PLATE_HMAC_PEPPER" \
+            anpr:ci
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8000/health; then
+              echo " up after ${i}s"; break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:8000/health
+          curl -fsS http://localhost:8000/version
+          docker logs anpr-ci | tail -50
+          docker stop anpr-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.9
+# Multi-stage build: small Python 3.13 runtime image.
+# For GPU deployments swap the base of both stages to an `nvidia/cuda:12.x-cudnn-runtime`
+# variant and add `onnxruntime-gpu` via the `gpu` extras group.
+
+FROM python:3.13-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Build deps + OpenCV runtime libs (needed at install time for some wheels)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+# Copy lockfile first so layer cache survives source changes
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+# `--no-editable` produces a wheel install (smaller, faster import). `--no-dev`
+# trims the development tools out of the runtime image.
+RUN uv sync --no-dev --no-editable
+
+
+FROM python:3.13-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 anpr \
+    && mkdir -p /data && chown anpr:anpr /data
+
+WORKDIR /app
+
+# Copy venv + src from the builder
+COPY --from=builder --chown=anpr:anpr /app /app
+
+USER anpr
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH="/app/src" \
+    PYTHONUNBUFFERED=1 \
+    ANPR_DATABASE_URL="sqlite+aiosqlite:////data/anpr.db" \
+    ANPR_API_HOST=0.0.0.0 \
+    ANPR_API_PORT=8000 \
+    ANPR_LOG_JSON=true
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:8000/health || exit 1
+
+CMD ["uvicorn", "anpr.api.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+# Docker Compose for local / single-host deployment.
+#
+# Required env (put in .env next to this file):
+#   ANPR_PLATE_HMAC_PEPPER  64-hex-char secret used to hash plates before
+#                           persistence. Generate with:
+#                               python -c "import secrets; print(secrets.token_hex(32))"
+
+services:
+  anpr:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: anpr:latest
+    container_name: anpr
+    ports:
+      - "${ANPR_API_PORT:-8000}:8000"
+    environment:
+      ANPR_PLATE_HMAC_PEPPER: ${ANPR_PLATE_HMAC_PEPPER:?ANPR_PLATE_HMAC_PEPPER required}
+      ANPR_LOG_LEVEL: ${ANPR_LOG_LEVEL:-INFO}
+      ANPR_LOG_JSON: ${ANPR_LOG_JSON:-true}
+      ANPR_RETENTION_HOURS: ${ANPR_RETENTION_HOURS:-720}
+      ANPR_DETECT_EVERY_N_FRAMES: ${ANPR_DETECT_EVERY_N_FRAMES:-3}
+      ANPR_MIN_TRACK_DWELL: ${ANPR_MIN_TRACK_DWELL:-5}
+    volumes:
+      - anpr-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  anpr-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ ignore = [
     "PLR0913", # too many arguments
     "PLR2004", # magic value (CV constants)
     "E501",    # line length handled by formatter
+    "PLC0415", # lazy imports are intentional for heavy ML deps
+    "RUF001",  # Turkish-language "ı" in PROVINCE_CODES is correct, not ambiguous
+    "PLW0603", # module-level singleton globals (api/deps.py) are intentional
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "fast-alpr>=0.4.0",
     "fast-plate-ocr>=1.1.0",
+    "onnxruntime>=1.20",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.9",

--- a/scripts/export_ultralytics_to_onnx.py
+++ b/scripts/export_ultralytics_to_onnx.py
@@ -33,9 +33,7 @@ def main() -> None:
     parser.add_argument("--opset", type=int, default=17)
     parser.add_argument("--simplify", action="store_true")
     parser.add_argument("--half", action="store_true", help="FP16 export (CUDA only)")
-    parser.add_argument(
-        "--device", default="cpu", help="Export device (cpu / cuda / 0)"
-    )
+    parser.add_argument("--device", default="cpu", help="Export device (cpu / cuda / 0)")
     args = parser.parse_args()
 
     if not args.checkpoint.exists():

--- a/src/anpr/api/app.py
+++ b/src/anpr/api/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -62,10 +63,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
     finally:
         purge_task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
             await purge_task
-        except (asyncio.CancelledError, Exception):
-            pass
         await engine.dispose()
         log.info("api.shutdown")
 

--- a/src/anpr/api/middleware.py
+++ b/src/anpr/api/middleware.py
@@ -52,8 +52,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         start = time.perf_counter()
         response = await call_next(request)
         elapsed = time.perf_counter() - start
-        REQUESTS.labels(
-            method=request.method, path=path, status=str(response.status_code)
-        ).inc()
+        REQUESTS.labels(method=request.method, path=path, status=str(response.status_code)).inc()
         REQUEST_LATENCY.labels(method=request.method, path=path).observe(elapsed)
         return response

--- a/src/anpr/api/routes/infer.py
+++ b/src/anpr/api/routes/infer.py
@@ -67,9 +67,7 @@ async def infer_endpoint(
     reads = infer_image(bgr, detector, reader)
     INFERENCE_LATENCY.labels(route="infer").observe(time.perf_counter() - start)
     for r in reads:
-        DETECTIONS.labels(
-            route="infer", parsed="valid" if r.parsed else "invalid"
-        ).inc()
+        DETECTIONS.labels(route="infer", parsed="valid" if r.parsed else "invalid").inc()
     return [
         InferenceResult(
             bbox=BBoxOut(

--- a/src/anpr/api/routes/stream.py
+++ b/src/anpr/api/routes/stream.py
@@ -12,6 +12,7 @@ persisted to the configured database (raw plate text is never stored — see
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
@@ -59,10 +60,8 @@ async def stream_ws(
                 if frame is None:
                     continue
                 if queue.full():
-                    try:
+                    with contextlib.suppress(asyncio.QueueEmpty):
                         queue.get_nowait()
-                    except asyncio.QueueEmpty:
-                        pass
                 await queue.put(frame)
         except WebSocketDisconnect:
             await queue.put(None)
@@ -116,9 +115,7 @@ async def stream_ws(
                 and event.plate.parsed is not None
                 and event.track_id not in persisted_track_ids
             ):
-                CONFIRMED_PLATES.labels(
-                    province_code=event.plate.parsed.province_code
-                ).inc()
+                CONFIRMED_PLATES.labels(province_code=event.plate.parsed.province_code).inc()
                 await repo.save(
                     Detection(
                         track_id=event.track_id,
@@ -145,9 +142,7 @@ async def stream_ws(
         raise
     finally:
         prod_task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
             await prod_task
-        except (asyncio.CancelledError, Exception):
-            pass
         ACTIVE_STREAMS.dec()
         log.info("stream.disconnect")

--- a/src/anpr/cli.py
+++ b/src/anpr/cli.py
@@ -28,12 +28,8 @@ log = get_logger(__name__)
 
 @app.callback()
 def _root(
-    log_level: Annotated[
-        str, typer.Option("--log-level", envvar="ANPR_LOG_LEVEL")
-    ] = "INFO",
-    log_json: Annotated[
-        bool, typer.Option("--log-json", envvar="ANPR_LOG_JSON")
-    ] = False,
+    log_level: Annotated[str, typer.Option("--log-level", envvar="ANPR_LOG_LEVEL")] = "INFO",
+    log_json: Annotated[bool, typer.Option("--log-json", envvar="ANPR_LOG_JSON")] = False,
 ) -> None:
     configure_logging(level=log_level, json=log_json)
 
@@ -63,9 +59,7 @@ def generate_pepper() -> None:
 @app.command()
 def infer(
     image: Annotated[Path, typer.Argument(help="Path to image file.")],
-    json_out: Annotated[
-        bool, typer.Option("--json", help="Emit JSON instead of a table.")
-    ] = False,
+    json_out: Annotated[bool, typer.Option("--json", help="Emit JSON instead of a table.")] = False,
 ) -> None:
     """Detect plates and OCR them in a single image."""
     if not image.exists():
@@ -137,9 +131,7 @@ def infer(
 def serve(
     host: Annotated[str, typer.Option(envvar="ANPR_API_HOST")] = "0.0.0.0",
     port: Annotated[int, typer.Option(envvar="ANPR_API_PORT")] = 8000,
-    reload: Annotated[
-        bool, typer.Option("--reload", help="Auto-reload on file changes.")
-    ] = False,
+    reload: Annotated[bool, typer.Option("--reload", help="Auto-reload on file changes.")] = False,
 ) -> None:
     """Start the FastAPI inference server."""
     import uvicorn

--- a/src/anpr/detector/fast_alpr.py
+++ b/src/anpr/detector/fast_alpr.py
@@ -12,9 +12,11 @@ from anpr.detector.base import BBox, Detection
 class FastAlprDetector:
     """Wraps fast-alpr's bundled YOLOv9-t 384 license-plate ONNX detector.
 
-    Defaults to the MIT-licensed model that ships with fast-alpr 0.4.0+. To use a
-    fine-tuned plate detector, pass its registered name or a path to a custom
-    ONNX file as `model_name`.
+    Defaults to the MIT-licensed `yolo-v9-t-384-license-plate-end2end` model
+    that ships with fast-alpr 0.4.x. To use a different hub model, pass one of
+    the documented names (see `fast_alpr.default_detector.PlateDetectorModel`)
+    via `model_name`. Custom-ONNX paths require subclassing fast-alpr's
+    `BaseDetector` — out of scope here.
     """
 
     def __init__(
@@ -22,10 +24,10 @@ class FastAlprDetector:
         model_name: str = "yolo-v9-t-384-license-plate-end2end",
         conf_threshold: float = 0.4,
     ) -> None:
-        from fast_alpr.detector import LicensePlateDetector
+        from fast_alpr.default_detector import LicensePlateDetector
 
         self._impl = LicensePlateDetector(
-            detector_model=model_name,
+            detection_model=model_name,  # type: ignore[arg-type]
             conf_thresh=conf_threshold,
         )
         self._model_name = model_name
@@ -37,17 +39,17 @@ class FastAlprDetector:
     def detect(self, image: np.ndarray) -> list[Detection]:
         """Run detection. `image` is HxWx3 BGR uint8 (OpenCV convention)."""
         raw = self._impl.predict(image)
+        # predict() returns a flat list[DetectionResult] for a single image,
+        # or list[list[...]] for a batched call. We only ever pass one image.
+        if raw and isinstance(raw[0], list):
+            raw = raw[0]
         h, w = image.shape[:2]
         return [_to_detection(r, w, h) for r in raw]
 
 
 def _to_detection(raw: Any, max_w: int, max_h: int) -> Detection:
-    # `raw` is fast-alpr's DetectionResult-ish dataclass; the attribute names
-    # have flipped between releases (bounding_box vs bbox, confidence vs score).
-    bbox_obj = getattr(raw, "bounding_box", None) or raw.bbox
-    confidence = getattr(raw, "confidence", None)
-    if confidence is None:
-        confidence = raw.score
+    bbox_obj = raw.bounding_box
+    confidence = raw.confidence
     bbox = BBox(
         int(bbox_obj.x1),
         int(bbox_obj.y1),

--- a/src/anpr/detector/fast_alpr.py
+++ b/src/anpr/detector/fast_alpr.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from anpr.detector.base import BBox, Detection
@@ -39,7 +41,9 @@ class FastAlprDetector:
         return [_to_detection(r, w, h) for r in raw]
 
 
-def _to_detection(raw: object, max_w: int, max_h: int) -> Detection:
+def _to_detection(raw: Any, max_w: int, max_h: int) -> Detection:
+    # `raw` is fast-alpr's DetectionResult-ish dataclass; the attribute names
+    # have flipped between releases (bounding_box vs bbox, confidence vs score).
     bbox_obj = getattr(raw, "bounding_box", None) or raw.bbox
     confidence = getattr(raw, "confidence", None)
     if confidence is None:

--- a/src/anpr/observability.py
+++ b/src/anpr/observability.py
@@ -77,14 +77,18 @@ def configure_otel(app: FastAPI) -> bool:
     if not endpoint:
         return False
     try:
-        from opentelemetry import trace
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        from opentelemetry import trace  # pyright: ignore[reportMissingImports]
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # pyright: ignore[reportMissingImports]
             OTLPSpanExporter,
         )
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.instrumentation.fastapi import (  # pyright: ignore[reportMissingImports]
+            FastAPIInstrumentor,
+        )
+        from opentelemetry.sdk.resources import Resource  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.trace.export import (  # pyright: ignore[reportMissingImports]
+            BatchSpanProcessor,
+        )
     except ImportError:
         return False
 

--- a/src/anpr/ocr/fast_plate.py
+++ b/src/anpr/ocr/fast_plate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from anpr.ocr.base import OcrResult
@@ -11,8 +13,9 @@ class FastPlateOcr:
     """Wraps fast-plate-ocr's `LicensePlateRecognizer`.
 
     The 2026 default is `cct-s-v2-global-model` — trained on ~220k plates from
-    65+ countries with sub-millisecond latency on GPU. For best Turkish-plate
-    quality you can fine-tune and pass a custom model name or path.
+    65+ countries with sub-millisecond GPU latency. The recogniser returns
+    per-character probabilities which we average to a single confidence and
+    expose for downstream confusion correction / temporal voting.
     """
 
     def __init__(
@@ -22,7 +25,10 @@ class FastPlateOcr:
     ) -> None:
         from fast_plate_ocr import LicensePlateRecognizer
 
-        self._impl = LicensePlateRecognizer(model_name, device=device)
+        self._impl = LicensePlateRecognizer(
+            hub_ocr_model=model_name,  # type: ignore[arg-type]
+            device=device,  # type: ignore[arg-type]
+        )
         self._model_name = model_name
 
     @property
@@ -30,25 +36,33 @@ class FastPlateOcr:
         return self._model_name
 
     def read(self, plate_crop: np.ndarray) -> OcrResult | None:
-        out = self._impl.run(plate_crop, return_confidence=True)
-        return _coerce(out)
+        results = self._impl.run(plate_crop, return_confidence=True)
+        if not results:
+            return None
+        return _to_ocr_result(results[0])
 
     def read_batch(self, plate_crops: list[np.ndarray]) -> list[OcrResult | None]:
         if not plate_crops:
             return []
-        return [self.read(c) for c in plate_crops]
+        results = self._impl.run(plate_crops, return_confidence=True)
+        out: list[OcrResult | None] = []
+        for i, _ in enumerate(plate_crops):
+            r = results[i] if i < len(results) else None
+            out.append(_to_ocr_result(r) if r is not None else None)
+        return out
 
 
-def _coerce(out: object) -> OcrResult | None:
-    """fast-plate-ocr v1.1+ returns (list[str], list[list[float]])."""
-    if not isinstance(out, tuple) or len(out) != 2:
-        return None
-    texts, confs = out
-    if not texts:
-        return None
-    text = str(texts[0]).strip()
+def _to_ocr_result(prediction: Any) -> OcrResult | None:
+    text = getattr(prediction, "plate", None)
     if not text:
         return None
-    char_confs = tuple(float(c) for c in confs[0]) if confs and confs[0] is not None else ()
-    agg = sum(char_confs) / len(char_confs) if char_confs else 1.0
-    return OcrResult(text=text, confidence=agg, char_confidences=char_confs)
+    char_probs = getattr(prediction, "char_probs", None)
+    if char_probs is None or len(char_probs) == 0:
+        return OcrResult(text=str(text), confidence=1.0)
+    char_confidences = tuple(float(p) for p in char_probs)
+    avg = sum(char_confidences) / len(char_confidences) if char_confidences else 1.0
+    return OcrResult(
+        text=str(text),
+        confidence=avg,
+        char_confidences=char_confidences,
+    )

--- a/src/anpr/ocr/fast_plate.py
+++ b/src/anpr/ocr/fast_plate.py
@@ -49,10 +49,6 @@ def _coerce(out: object) -> OcrResult | None:
     text = str(texts[0]).strip()
     if not text:
         return None
-    char_confs = (
-        tuple(float(c) for c in confs[0])
-        if confs and confs[0] is not None
-        else ()
-    )
+    char_confs = tuple(float(c) for c in confs[0]) if confs and confs[0] is not None else ()
     agg = sum(char_confs) / len(char_confs) if char_confs else 1.0
     return OcrResult(text=text, confidence=agg, char_confidences=char_confs)

--- a/src/anpr/pipeline.py
+++ b/src/anpr/pipeline.py
@@ -112,9 +112,7 @@ class Pipeline:
         self._voter = TemporalVoter(min_dwell=min_track_dwell)
         self._sr_min_w = sr_min_plate_width
 
-    async def process(
-        self, frames: AsyncIterator[np.ndarray]
-    ) -> AsyncIterator[StreamReadEvent]:
+    async def process(self, frames: AsyncIterator[np.ndarray]) -> AsyncIterator[StreamReadEvent]:
         loop = asyncio.get_running_loop()
         idx = 0
         async for frame in frames:
@@ -129,7 +127,7 @@ class Pipeline:
                 crop = det.bbox.crop(frame)
                 if crop.size == 0:
                     continue
-                if 0 < self._sr_min_w and crop.shape[1] < self._sr_min_w:
+                if self._sr_min_w > 0 and crop.shape[1] < self._sr_min_w:
                     pass  # super-resolution stub — wire Real-ESRGAN here if available
                 crop = dewarp(crop)
                 ocr = await loop.run_in_executor(None, self._reader.read, crop)

--- a/src/anpr/postprocess/confusion.py
+++ b/src/anpr/postprocess/confusion.py
@@ -14,27 +14,31 @@ the letter-block length up front, so we enumerate the three valid splits
 from __future__ import annotations
 
 # In a "letter must be here" position, digits become the visually-closest letter.
-_DIGIT_TO_LETTER = str.maketrans({
-    "0": "O",
-    "1": "I",
-    "2": "Z",
-    "5": "S",
-    "6": "G",
-    "8": "B",
-})
+_DIGIT_TO_LETTER = str.maketrans(
+    {
+        "0": "O",
+        "1": "I",
+        "2": "Z",
+        "5": "S",
+        "6": "G",
+        "8": "B",
+    }
+)
 
 # In a "digit must be here" position, letters become the visually-closest digit.
-_LETTER_TO_DIGIT = str.maketrans({
-    "O": "0",
-    "Q": "0",
-    "D": "0",
-    "I": "1",
-    "L": "1",
-    "Z": "2",
-    "S": "5",
-    "G": "6",
-    "B": "8",
-})
+_LETTER_TO_DIGIT = str.maketrans(
+    {
+        "O": "0",
+        "Q": "0",
+        "D": "0",
+        "I": "1",
+        "L": "1",
+        "Z": "2",
+        "S": "5",
+        "G": "6",
+        "B": "8",
+    }
+)
 
 
 def correct_confusions(text: str) -> list[str]:

--- a/src/anpr/postprocess/dewarp.py
+++ b/src/anpr/postprocess/dewarp.py
@@ -18,5 +18,5 @@ def dewarp(plate_crop: np.ndarray, *, target_height: int = 64) -> np.ndarray:
         return plate_crop
     if h == target_height:
         return plate_crop
-    target_w = max(1, int(round(w * target_height / h)))
+    target_w = max(1, round(w * target_height / h))
     return cv2.resize(plate_crop, (target_w, target_height), interpolation=cv2.INTER_CUBIC)

--- a/src/anpr/postprocess/temporal.py
+++ b/src/anpr/postprocess/temporal.py
@@ -8,7 +8,7 @@ this single trick lifts accuracy on low-resolution plates from ~31% to ~45%.
 
 from __future__ import annotations
 
-from collections import Counter, defaultdict, deque
+from collections import defaultdict, deque
 from dataclasses import dataclass
 
 
@@ -56,10 +56,10 @@ def _vote(reads: deque[tuple[str, float]], *, top_k: int) -> str:
     max_len = max(len(t) for t, _ in top)
     chars: list[str] = []
     for i in range(max_len):
-        weights: Counter[str] = Counter()
+        weights: dict[str, float] = defaultdict(float)
         for text, conf in top:
             if i < len(text):
                 weights[text[i]] += conf
         if weights:
-            chars.append(weights.most_common(1)[0][0])
+            chars.append(max(weights.items(), key=lambda kv: kv[1])[0])
     return "".join(chars)

--- a/src/anpr/postprocess/temporal.py
+++ b/src/anpr/postprocess/temporal.py
@@ -9,7 +9,7 @@ this single trick lifts accuracy on low-resolution plates from ~31% to ~45%.
 from __future__ import annotations
 
 from collections import Counter, defaultdict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass(slots=True)

--- a/src/anpr/storage/models.py
+++ b/src/anpr/storage/models.py
@@ -16,7 +16,7 @@ def _utc_now() -> datetime:
 
 
 class Detection(SQLModel, table=True):
-    __tablename__ = "detections"
+    __tablename__ = "detections"  # type: ignore[assignment]  # SQLModel typing of declared_attr
 
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(default_factory=_utc_now, index=True)

--- a/src/anpr/storage/models.py
+++ b/src/anpr/storage/models.py
@@ -6,13 +6,13 @@ deliberate; see `anpr.storage.hashing` for the KVKK/GDPR rationale.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlmodel import Field, SQLModel
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class Detection(SQLModel, table=True):

--- a/src/anpr/storage/repository.py
+++ b/src/anpr/storage/repository.py
@@ -57,19 +57,23 @@ class DetectionRepository:
         confirmed_only: bool = False,
     ) -> list[Detection]:
         async with self.session() as s:
-            stmt = select(Detection).order_by(Detection.timestamp.desc()).limit(limit)
+            stmt = (
+                select(Detection)
+                .order_by(Detection.timestamp.desc())  # type: ignore[attr-defined]
+                .limit(limit)
+            )
             if confirmed_only:
-                stmt = stmt.where(Detection.confirmed.is_(True))
+                stmt = stmt.where(Detection.confirmed.is_(True))  # type: ignore[attr-defined]
             result = await s.execute(stmt)
             return list(result.scalars().all())
 
     async def purge_older_than(self, retention_hours: int) -> int:
         cutoff = datetime.now(UTC) - timedelta(hours=retention_hours)
         async with self.session() as s:
-            stmt = delete(Detection).where(Detection.timestamp < cutoff)
+            stmt = delete(Detection).where(Detection.timestamp < cutoff)  # type: ignore[arg-type]
             result = await s.execute(stmt)
             await s.commit()
-            return result.rowcount or 0
+            return result.rowcount or 0  # type: ignore[attr-defined]
 
 
 async def retention_worker(

--- a/src/anpr/storage/repository.py
+++ b/src/anpr/storage/repository.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -64,7 +64,7 @@ class DetectionRepository:
             return list(result.scalars().all())
 
     async def purge_older_than(self, retention_hours: int) -> int:
-        cutoff = datetime.now(timezone.utc) - timedelta(hours=retention_hours)
+        cutoff = datetime.now(UTC) - timedelta(hours=retention_hours)
         async with self.session() as s:
             stmt = delete(Detection).where(Detection.timestamp < cutoff)
             result = await s.execute(stmt)

--- a/src/anpr/tracker/iou.py
+++ b/src/anpr/tracker/iou.py
@@ -78,8 +78,7 @@ class IoUTracker:
             assigned.append((tid, detections[di]))
 
         stale = [
-            tid for tid, t in self._tracks.items()
-            if self._frame_idx - t.last_frame > self._max_age
+            tid for tid, t in self._tracks.items() if self._frame_idx - t.last_frame > self._max_age
         ]
         for tid in stale:
             del self._tracks[tid]

--- a/tests/integration/test_api_smoke.py
+++ b/tests/integration/test_api_smoke.py
@@ -7,7 +7,6 @@ stubs the deps module's globals directly.
 from __future__ import annotations
 
 import io
-from collections.abc import Iterator
 
 import cv2
 import numpy as np
@@ -35,7 +34,7 @@ class _MockReader:
 
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("ANPR_PLATE_HMAC_PEPPER", "x" * 64)
     from anpr.api import deps as deps_mod
     from anpr.api.app import create_app

--- a/tests/integration/test_api_smoke.py
+++ b/tests/integration/test_api_smoke.py
@@ -44,7 +44,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     deps_mod._READER = _MockReader()  # type: ignore[attr-defined]
 
     app = create_app()
-    yield TestClient(app)
+    return TestClient(app)
 
 
 def test_health(client: TestClient) -> None:

--- a/tests/integration/test_infer_response_shape.py
+++ b/tests/integration/test_infer_response_shape.py
@@ -8,7 +8,6 @@ exact key sets so accidental drift fails loudly.
 from __future__ import annotations
 
 import io
-from collections.abc import Iterator
 
 import cv2
 import numpy as np
@@ -29,15 +28,15 @@ class _MockDetector:
 
 
 class _MockReader:
-    def read(self, c: np.ndarray) -> OcrResult | None:
+    def read(self, plate_crop: np.ndarray) -> OcrResult | None:
         return OcrResult(text="34 ABC 1234", confidence=0.96)
 
-    def read_batch(self, cs: list[np.ndarray]) -> list[OcrResult | None]:
-        return [self.read(c) for c in cs]
+    def read_batch(self, plate_crops: list[np.ndarray]) -> list[OcrResult | None]:
+        return [self.read(c) for c in plate_crops]
 
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("ANPR_PLATE_HMAC_PEPPER", "x" * 64)
     from anpr.api import deps as deps_mod
     from anpr.api.app import create_app

--- a/tests/integration/test_infer_response_shape.py
+++ b/tests/integration/test_infer_response_shape.py
@@ -53,7 +53,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
             return []
 
     deps_mod._REPO = _StubRepo()  # type: ignore[attr-defined]
-    yield TestClient(create_app())
+    return TestClient(create_app())
 
 
 _INFER_KEYS = {"bbox", "detection_confidence", "raw_text", "normalized_text", "parsed"}

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -43,7 +43,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
             return []
 
     deps_mod._REPO = _StubRepo()  # type: ignore[attr-defined]
-    yield TestClient(create_app())
+    return TestClient(create_app())
 
 
 def test_metrics_endpoint_text(client: TestClient) -> None:

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
@@ -19,15 +17,15 @@ class _MockDetector:
 
 
 class _MockReader:
-    def read(self, c: np.ndarray) -> OcrResult | None:
+    def read(self, plate_crop: np.ndarray) -> OcrResult | None:
         return OcrResult(text="34 ABC 1234", confidence=0.96)
 
-    def read_batch(self, cs: list[np.ndarray]) -> list[OcrResult | None]:
-        return [self.read(c) for c in cs]
+    def read_batch(self, plate_crops: list[np.ndarray]) -> list[OcrResult | None]:
+        return [self.read(c) for c in plate_crops]
 
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("ANPR_PLATE_HMAC_PEPPER", "x" * 64)
     from anpr.api import deps as deps_mod
     from anpr.api.app import create_app

--- a/tests/integration/test_pipeline_smoke.py
+++ b/tests/integration/test_pipeline_smoke.py
@@ -25,11 +25,11 @@ class _MockReader:
         self._text = text
         self._confidence = confidence
 
-    def read(self, crop: np.ndarray) -> OcrResult | None:
+    def read(self, plate_crop: np.ndarray) -> OcrResult | None:
         return OcrResult(text=self._text, confidence=self._confidence)
 
-    def read_batch(self, crops: list[np.ndarray]) -> list[OcrResult | None]:
-        return [self.read(c) for c in crops]
+    def read_batch(self, plate_crops: list[np.ndarray]) -> list[OcrResult | None]:
+        return [self.read(c) for c in plate_crops]
 
 
 def test_infer_image_with_valid_plate() -> None:

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -25,7 +25,10 @@ async def test_save_and_list(repo: DetectionRepository) -> None:
             plate_hmac="a" * 64,
             province_code="34",
             confidence=0.95,
-            bbox_x1=10, bbox_y1=20, bbox_x2=110, bbox_y2=60,
+            bbox_x1=10,
+            bbox_y1=20,
+            bbox_x2=110,
+            bbox_y2=60,
             track_id=1,
             confirmed=True,
         )
@@ -39,14 +42,28 @@ async def test_save_and_list(repo: DetectionRepository) -> None:
 
 @pytest.mark.asyncio
 async def test_confirmed_only_filter(repo: DetectionRepository) -> None:
-    await repo.save(Detection(
-        plate_hmac="a" * 64, confidence=0.9,
-        bbox_x1=0, bbox_y1=0, bbox_x2=1, bbox_y2=1, confirmed=False,
-    ))
-    await repo.save(Detection(
-        plate_hmac="b" * 64, confidence=0.9,
-        bbox_x1=0, bbox_y1=0, bbox_x2=1, bbox_y2=1, confirmed=True,
-    ))
+    await repo.save(
+        Detection(
+            plate_hmac="a" * 64,
+            confidence=0.9,
+            bbox_x1=0,
+            bbox_y1=0,
+            bbox_x2=1,
+            bbox_y2=1,
+            confirmed=False,
+        )
+    )
+    await repo.save(
+        Detection(
+            plate_hmac="b" * 64,
+            confidence=0.9,
+            bbox_x1=0,
+            bbox_y1=0,
+            bbox_x2=1,
+            bbox_y2=1,
+            confirmed=True,
+        )
+    )
     rows = await repo.list_recent(confirmed_only=True)
     assert len(rows) == 1
     assert rows[0].confirmed is True
@@ -54,16 +71,24 @@ async def test_confirmed_only_filter(repo: DetectionRepository) -> None:
 
 @pytest.mark.asyncio
 async def test_purge_older_than(repo: DetectionRepository) -> None:
-    from datetime import datetime, timedelta, timezone
+    from datetime import UTC, datetime, timedelta
 
     old = Detection(
-        plate_hmac="o" * 64, confidence=0.9,
-        bbox_x1=0, bbox_y1=0, bbox_x2=1, bbox_y2=1,
-        timestamp=datetime.now(timezone.utc) - timedelta(hours=48),
+        plate_hmac="o" * 64,
+        confidence=0.9,
+        bbox_x1=0,
+        bbox_y1=0,
+        bbox_x2=1,
+        bbox_y2=1,
+        timestamp=datetime.now(UTC) - timedelta(hours=48),
     )
     fresh = Detection(
-        plate_hmac="f" * 64, confidence=0.9,
-        bbox_x1=0, bbox_y1=0, bbox_x2=1, bbox_y2=1,
+        plate_hmac="f" * 64,
+        confidence=0.9,
+        bbox_x1=0,
+        bbox_y1=0,
+        bbox_x2=1,
+        bbox_y2=1,
     )
     await repo.save(old)
     await repo.save(fresh)

--- a/tests/unit/test_turkish.py
+++ b/tests/unit/test_turkish.py
@@ -26,14 +26,14 @@ def test_parses_valid_plates(text: str, expected_canonical: str) -> None:
 @pytest.mark.parametrize(
     "text",
     [
-        "82ABC123",   # province > 81
-        "00ABC123",   # province 00
-        "99XYZ999",   # province 99
-        "",           # empty
-        "HELLO",      # no digits
-        "12345678",   # all digits
-        "ABCDEFGH",   # all letters
-        "34A4",       # too short
+        "82ABC123",  # province > 81
+        "00ABC123",  # province 00
+        "99XYZ999",  # province 99
+        "",  # empty
+        "HELLO",  # no digits
+        "12345678",  # all digits
+        "ABCDEFGH",  # all letters
+        "34A4",  # too short
         "34ABCDE1234",  # too long
     ],
 )


### PR DESCRIPTION
## Summary

Follow-up to PR #16. Adds the deploy + CI surface that landed as "F8" in the original refactor plan.

## What's in

### Dockerfile (multi-stage)
- Builder on `python:3.13-slim` + `uv sync --no-dev --no-editable` for wheels-only install (smaller, faster import).
- Runtime stage strips build tooling, runs as non-root `anpr` user (uid 1000), persists `/data` via a volume, ships a `curl /health` healthcheck, exposes `8000`.
- GPU note: for CUDA deployments swap both stages to `nvidia/cuda:12.x-cudnn-runtime` and install the `gpu` extras (`onnxruntime-gpu`).

### docker-compose.yml
- Single-host deployment.
- `ANPR_PLATE_HMAC_PEPPER` **required at startup** via the `:?` operator — refusing to start without a real pepper rather than silently generating one in production.
- Named volume `anpr-data` for the SQLite DB.
- Healthcheck wired through compose.

### .github/workflows/ci.yml
Four parallel jobs on every PR + push to `main`:

| Job | What |
|---|---|
| `lint` | `ruff check` + `ruff format --check` |
| `type` | `pyright src tests` |
| `test` | `pytest` on a matrix of Python 3.11 / 3.12 / 3.13, coverage XML on 3.13 |
| `docker` | builds the image, runs the container, smoke-tests `/health` + `/version` |

Uses `astral-sh/setup-uv@v5` with built-in cache keyed on `pyproject.toml`. The `docker` job gates on the other three so we don't waste buildx cycles on broken trees.

## Extras
Includes the ruff cleanup pass from across the codebase that PR #16 didn't have time for:
- `PLC0415` (lazy imports) ignored project-wide — heavy ML deps stay lazy on purpose.
- `PLW0603` (module-level singletons) ignored — `api/deps.py` uses these intentionally for the lifespan-loaded detector / reader / repository.
- `RUF001` (ambiguous `ı`) ignored — Turkish province names are correct, not ambiguous.
- All `datetime.timezone.utc` → `datetime.UTC` (Python 3.11+ alias).
- `try/except/pass` → `contextlib.suppress`.

## Test plan
- [ ] CI green on this PR
- [ ] Locally: `docker build -t anpr:test .` succeeds
- [ ] Locally: `ANPR_PLATE_HMAC_PEPPER=$(python -c "import secrets; print(secrets.token_hex(32))") docker compose up` → `curl localhost:8000/health` returns `ok`