### PR TITLE
docs: modernize README + add KVKK Aydınlatma Metni template

### DIFF
--- a/KVKK_AYDINLATMA_METNI.md
+++ b/KVKK_AYDINLATMA_METNI.md
@@ -1,0 +1,112 @@
+# KVKK Aydınlatma Metni — Plaka Tanıma Sistemi
+
+> **Bu belge bir başlangıç şablonudur, hukuki tavsiye değildir.** Sisteminizi kurmadan
+> önce kendi veri sorumlusu/işleyen ilişkinizi, hukuki sebebinizi, saklama sürelerinizi,
+> teknik ve idari tedbirlerinizi bir hukuk danışmanı ile gözden geçirin. Ticari/kamu
+> dağıtımlar için VERBİS kaydı, açık rıza akışı, DPIA (etki değerlendirmesi) ve
+> sözleşme zinciri (varsa veri işleyen, alt işleyenler) ayrıca değerlendirilmelidir.
+
+6698 sayılı **Kişisel Verilerin Korunması Kanunu** ("KVKK") uyarınca; bu belge,
+araç plakanızın bu sistem tarafından işlenmesi sürecine ilişkin sizi
+aydınlatmak amacıyla hazırlanmıştır.
+
+## 1. Veri Sorumlusu
+
+- **Veri Sorumlusu:** _[Kurum/Şirket adı]_
+- **Adres:** _[Tam adres]_
+- **VKN/MERSİS:** _[Numara]_
+- **İletişim:** _[E-posta / telefon]_
+- **VERBİS:** _[Sicil numarası, varsa]_
+
+## 2. İşlenen Kişisel Veriler
+
+Bu sistem aracılığıyla aşağıdaki kişisel veriler işlenmektedir:
+
+| Veri Kategorisi | Veri Türü | Toplama Yöntemi |
+|---|---|---|
+| Araç ve Bağlı Kişi Verisi | Plaka metni (HMAC-SHA256 ile **şifrelenmiş** olarak saklanır; ham metin **kalıcı şekilde saklanmaz**) | Kameradan/yüklenen görselden otomatik tespit + OCR |
+| İşlem Verisi | Tespit zaman damgası, takip kimliği, güven skoru, görüntüdeki sınır kutusu koordinatları | Otomatik üretim |
+| _(Opsiyonel)_ Görsel | Kamera görüntüsünde yer alan diğer kişi/araç/ortam verisi | Kameradan/yüklemeden |
+
+> ⚠ **Önemli:** Sistem varsayılan olarak plaka metnini saklamaz; yalnızca
+> deployment-spesifik bir gizli anahtar (`ANPR_PLATE_HMAC_PEPPER`) ile
+> HMAC-SHA256 özetini saklar. Bu özet, **aynı plaka için aynı değeri**
+> üretmesine rağmen anahtar olmadan tersine çevrilemez.
+
+## 3. Kişisel Verilerin İşlenme Amaçları
+
+- _[Örnek] Tesise/Otoparka giriş-çıkış kontrolünün otomatik gerçekleştirilmesi_
+- _[Örnek] İzinsiz araç girişi durumunda güvenlik birimini uyarma_
+- _[Örnek] Otopark süresi bazlı ücretlendirme_
+- Yasal yükümlülüklerin yerine getirilmesi
+- Sistemin teknik bakım, hata ayıklama ve iyileştirilmesi (toplu / anonim metriklerle)
+
+## 4. Kişisel Verilerin İşlenmesinin Hukuki Sebebi
+
+Aşağıdakilerden uygun olan(lar)ı seçilmelidir (KVKK md. 5):
+
+- [ ] Açık rıza (md. 5/1)
+- [ ] Kanunlarda açıkça öngörülmesi (md. 5/2-a)
+- [ ] Bir sözleşmenin kurulması veya ifasıyla doğrudan doğruya ilgili olması (md. 5/2-c)
+- [ ] Veri sorumlusunun hukuki yükümlülüğünü yerine getirebilmesi için zorunlu olması (md. 5/2-ç)
+- [ ] **İlgili kişinin temel hak ve özgürlüklerine zarar vermemek kaydıyla, veri sorumlusunun meşru menfaatleri için zorunlu olması** (md. 5/2-f) — özel güvenlik / otopark erişim kontrolü senaryosunda yaygın olarak kullanılır
+
+## 5. Kişisel Verilerin Aktarımı
+
+- **Yurtiçi aktarım:** _[Hangi alıcı gruplarına aktarılıyor? Örn. yetkili kamu kurumları, hizmet aldığınız teknoloji sağlayıcılar]_
+- **Yurtdışı aktarım:** _[Varsa, hangi ülke + KVKK Kurulu yeterlilik kararı / taahhütname / BCR]_
+
+## 6. Saklama Süresi
+
+Bu sistemde varsayılan saklama süresi **`ANPR_RETENTION_HOURS` ortam değişkeni**
+ile yapılandırılır (kurulum varsayılanı 720 saat = 30 gün). Süre dolduğunda
+arka plan iş parçacığı kayıtları otomatik olarak siler.
+
+- _[Sizin saklama süreniz, ör. "Otopark giriş-çıkış tutanakları 6 ay süreyle saklanır."]_
+- Saklama ve İmha Politikası: _[varsa, link / referans]_
+
+## 7. İlgili Kişinin Hakları (KVKK md. 11)
+
+Kişisel verisi işlenen kişi olarak siz, aşağıdaki haklara sahipsiniz:
+
+- Kişisel verinizin işlenip işlenmediğini öğrenme
+- İşlenmişse buna ilişkin bilgi talep etme
+- İşlenme amacını ve amacına uygun kullanılıp kullanılmadığını öğrenme
+- Yurt içinde / yurt dışında aktarıldığı üçüncü kişileri bilme
+- Eksik veya yanlış işlenmiş ise düzeltilmesini isteme
+- KVKK ve ilgili mevzuat çerçevesinde silinmesini / yok edilmesini isteme
+- Düzeltme / silme / yok etme işlemlerinin üçüncü kişilere bildirilmesini isteme
+- Otomatik sistemlerle analiz edilmesi sonucu aleyhinize sonuç doğmasına itiraz etme
+- Kanuna aykırı işleme nedeniyle zarara uğradığınızda zararın giderilmesini talep etme
+
+Başvurularınızı, **Veri Sorumlusuna Başvuru Usul ve Esasları Hakkında Tebliğ**
+hükümlerine uygun olarak aşağıdaki kanalları kullanarak iletebilirsiniz:
+
+- E-posta: _[KEP veya kayıtlı e-posta]_
+- Yazılı: _[Adres]_
+- Form: _[Varsa link]_
+
+Başvurunuz en geç **30 gün** içinde yanıtlanır. Ücretsizdir; ayrıca bir maliyet
+gerekirse Kurul'ca belirlenen tarifeye göre ücret talep edilebilir.
+
+## 8. Teknik ve İdari Tedbirler
+
+Bu sistemde alınan başlıca tedbirler:
+
+- **Şifreleme:** Plaka metni HMAC-SHA256 + deployment-spesifik gizli anahtar
+  (pepper) ile özetlenip saklanır. Ham metin veritabanına yazılmaz.
+- **Erişim kontrolü:** API ve veritabanı yalnızca yetkili kişiler tarafından
+  erişilebilir; CORS / auth katmanları kurulum sırasında yapılandırılmalıdır.
+- **Asgari veri:** Yalnızca amaç için gerekli alanlar saklanır (zaman damgası,
+  güven skoru, sınır kutusu, plaka özeti, il kodu).
+- **Otomatik silme:** Saklama süresi aşıldığında arka plan iş parçacığı
+  kayıtları siler.
+- **Loglama:** Erişim ve sistem olayları yapılandırılmış formatta loglanır
+  (structlog + opsiyonel OpenTelemetry).
+- **Süreç:** _[İlgili politikalar — Bilgi Güvenliği Politikası, İmha Politikası, vb.]_
+
+---
+
+_Aydınlatma Metni Versiyon:_ 1.0  
+_Yürürlük Tarihi:_ _[YYYY-AA-GG]_  
+_Son Güncelleme:_ _[YYYY-AA-GG]_

--- a/README.md
+++ b/README.md
@@ -1,105 +1,214 @@
-# Automatic Number Plate Recognition
+# anpr — Automatic Number Plate Recognition
 
-![dataset-cover](https://user-images.githubusercontent.com/57320216/166916670-03dfabe1-8c6c-471a-875c-8715354aa957.jpg)
+[![CI](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/actions/workflows/ci.yml/badge.svg)](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/actions/workflows/ci.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%E2%80%933.13-blue.svg)](pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-**Automatic Number Plate Recognition (ANPR)** is the process of reading the characters on the plate with various optical character recognition (OCR) methods by separating the plate region on the vehicle image obtained from automatic plate recognition.
+End-to-end license plate recognition: **plate detection → tracking → OCR → Turkish format parsing → temporal voting → privacy-aware persistence**, served behind a FastAPI HTTP + WebSocket API.
 
-## Table of Content
+> Originally written in 2022 with a YOLOv5 fork + EasyOCR + Flask 1.1. Rewritten in 2026 on top of [`fast-alpr`](https://github.com/ankandrew/fast-alpr) + [`fast-plate-ocr`](https://github.com/ankandrew/fast-plate-ocr) + FastAPI + uv. The original code is preserved verbatim under [`legacy/`](legacy/) for reference.
 
-- [Automatic Number Plate Recognition](#automatic-number-plate-recognition)
+---
 
-  * [What will you learn this project ](#what-will-you-learn-this-project)
-  * [Dataset](#dataset)
-  * [Installation](#installation)
-  * [Usage](#usage)
-  * [Project architecture](#project-architecture)
-  * [Some Result](#some-result)
-  * [Source](#source)
-  * [Licence](#licence)
+## Quickstart
 
+### Docker (recommended)
 
-## What will you learn this project 
+```bash
+export ANPR_PLATE_HMAC_PEPPER="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+docker compose up --build
+```
 
-* Custom Object Detection
-* Scene Text Detection
-* Scene Text Recognation
-* Optic Character Recognation
-* EasyOCR, PaddleOCR
-* Database,CSV format
-* Applying project in Real Time
-* Flask
-## Dataset
-The dataset I use for license plate detection:  
+Open <http://localhost:8000>.
 
-https://www.kaggle.com/datasets/andrewmvd/car-plate-detection
+### Native, via `uv`
 
-## Installation
+```bash
+git clone https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR.git
+cd Automatic_Number_Plate_Recognition_YOLO_OCR
+uv sync --all-extras --group dev
+cp .env.example .env
+# Generate a pepper and paste it into .env
+uv run anpr generate-pepper
+uv run anpr serve            # FastAPI on http://localhost:8000
+# or: single-image inference
+uv run anpr infer tests/fixtures/sample_plate.jpg
+```
 
-Clone repo and install requirements.txt in a Python>=3.7.0 environment.
+---
 
-    git clone https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR.git  # clone
-    cd Automatic-number-plate-recognition-YOLO-OCR
-    pip install -r requirements.txt  # install
+## What's in the box
 
-## Usage
+| Layer | Implementation |
+|---|---|
+| **Detector** | [`fast-alpr`](https://github.com/ankandrew/fast-alpr)'s bundled YOLOv9-t 384 ONNX license-plate model (MIT, 65+ countries) |
+| **OCR** | [`fast-plate-ocr`](https://github.com/ankandrew/fast-plate-ocr) `cct-s-v2-global-model` (sub-millisecond GPU, per-character confidences) |
+| **Tracker** | Dependency-free greedy IoU tracker (swap to ByteTrack via the `Tracker` Protocol) |
+| **Turkish parser** | All 81 province codes, strict regex on `NN [A]{1-3} [N]{2-4}` |
+| **Confusion fix** | Position-aware OCR fixups (0/O, 1/I/L, 5/S, 8/B, 2/Z, 6/G, 0/D/Q) |
+| **Temporal voting** | Per-character-position majority vote over top-K confidence-weighted reads per track |
+| **Web** | FastAPI 0.115 + uvicorn, REST + WebSocket, dark-theme HTMX UI |
+| **Storage** | SQLModel + aiosqlite default; HMAC-SHA256 plate hashing (no raw plate text ever stored) |
+| **Observability** | structlog + Prometheus `/metrics` + opt-in OpenTelemetry (`otel` extras) |
+| **Packaging** | `uv` + `pyproject.toml`, `ruff` (lint + format), `pyright`, `pytest` (60+ tests) |
 
-After the req libraries are installed, you can run the project by main.py.
+---
 
-    python main.py
+## API surface
 
-## Project architecture
+| Endpoint | Method | What |
+|---|---|---|
+| `/` | GET | HTMX UI (upload + live webcam) |
+| `/health` | GET | k8s probe |
+| `/version` | GET | running version |
+| `/metrics` | GET | Prometheus text-format metrics |
+| `/api/v1/infer` | POST (multipart) | single-image inference |
+| `/api/v1/detections` | GET | recent persisted reads (HMAC-hashed) |
+| `/ws/stream` | WS | binary JPEG frames in → JSON read events out |
 
-The pipeline in the project is as follows:  
+Full OpenAPI at <http://localhost:8000/docs>.
 
-![images](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/imgs/flowchart.png)
+---
 
-- Custom object detection with plate extraction using yolov5
-- Apply the extracted plate to EasyOCR and PaddleOCR
-- Get plate text
-- Filter text
-- Write Database and CSV format
-- Upload to Flask  
+## Architecture
 
+```
+┌──────────────────────┐       ┌─────────────────────┐
+│  Webcam / Upload     │──────►│  FastAPI            │
+└──────────────────────┘       │   /infer  /ws/stream │
+                               └──────────┬──────────┘
+                                          ▼
+┌──────────────────────────────────────────────────────┐
+│  Pipeline (async, frame-skip + drop-on-full queue)   │
+│                                                       │
+│   Detector ──► IoUTracker ──► dewarp ──► PlateReader  │
+│    fast-alpr      greedy        cv2       fast-plate  │
+│      ONNX                                    ONNX     │
+│                       │                               │
+│                       ▼                               │
+│              parse_turkish_plate                      │
+│              correct_confusions                       │
+│              TemporalVoter (majority)                 │
+└──────────────────────────────────────────────────────┘
+                                          │
+                                          ▼
+┌──────────────────────┐       ┌─────────────────────┐
+│  SQLite / Postgres   │◄──────│  HMAC-SHA256(plate)  │
+│  (only hashes)       │       │  KVKK + GDPR safe    │
+└──────────────────────┘       └─────────────────────┘
+```
 
-## Some Result
+---
 
-* As you can see, first step is detect the plate with using Yolov5. 
+## Configuration
 
-![images](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/imgs/realtime.png)
+All settings live under the `ANPR_` env prefix and can be overridden via `.env`. See [`.env.example`](.env.example) for the full reference.
 
-* After detect plate, apply the ocr. Paddle ocr Easy ocr for recognizing plate.  
+| Env | Default | Notes |
+|---|---|---|
+| `ANPR_PLATE_HMAC_PEPPER` | _(generated; warns)_ | **Required in prod.** Generate with `anpr generate-pepper`. Must be ≥ 32 chars. |
+| `ANPR_DATABASE_URL` | `sqlite+aiosqlite:///data/anpr.db` | Switch to `postgresql+asyncpg://...` for production. |
+| `ANPR_RETENTION_HOURS` | `720` (30d) | Background worker purges rows older than this. |
+| `ANPR_DETECT_EVERY_N_FRAMES` | `3` | Detect on every Nth frame; track between. |
+| `ANPR_MIN_TRACK_DWELL` | `5` | Frames a track must persist before the voter emits confirmed. |
+| `ANPR_DETECTOR_MODEL` | `yolo-v9-t-384-license-plate-end2end` | Pass a path to use a fine-tuned ONNX. |
+| `ANPR_OCR_MODEL` | `cct-s-v2-global-model` | fast-plate-ocr model name. |
+| `ANPR_DEVICE` | `auto` | `auto` / `cpu` / `cuda` / `openvino`. |
+| `ANPR_LOG_JSON` | `false` | Set to `true` for structured logs to OTLP / Loki. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | When set, installs OTel FastAPI instrumentation (requires `otel` extras). |
 
-![images](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/imgs/plate_recog.jpg)
+---
 
-* Then write csv or database, when put it all in one.  
+## Privacy — KVKK & GDPR
 
-![images](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/imgs/all.png)
+License plates are **personal data** under both Türkiye's KVKK (Law 6698, art. 3(d)) and the EU GDPR (Reg. 2016/679 art. 4(1)). This project is privacy-aware by default:
 
-* The last step is Flask :) Actually, I didn't have time to integrate all the code in Flask. I just uploaded the yolov5 part. If you do, don't forget to pull request :)  
+- Plates are **never stored as plaintext**. The database holds only HMAC-SHA256 of the normalized plate string, salted with a per-deployment pepper. Hashes are deterministic for matching but not reversible without the pepper.
+- A retention worker purges rows older than `ANPR_RETENTION_HOURS` automatically.
+- The web UI (`templates/index.html`) shows the human-readable plate live in the browser but does **not** persist the raw text.
 
-![images](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/imgs/flask_test.png)
+If you deploy this for an organization, you'll likely need to publish a KVKK Aydınlatma Metni / GDPR Article 13 notice. A starter template is in [`KVKK_AYDINLATMA_METNI.md`](KVKK_AYDINLATMA_METNI.md) — **adapt it to your actual processing context, this is not legal advice.**
 
+---
 
-## Similar work
-A streamlit based implementation of Automatic Number Plate Recognition for cars and other vehicles using images or live camera feed.
+## Development
 
-![Animation](https://user-images.githubusercontent.com/29462447/168389056-9f39b89d-1221-432b-878d-578d9114d466.gif)
-![live feed demo](https://user-images.githubusercontent.com/29462447/168389042-c06f3dd2-5047-4138-8c11-07372d63046a.gif)
+```bash
+uv sync --all-extras --group dev
+make lint       # ruff check + format check
+make type       # pyright
+make test       # pytest (60+ tests)
+make serve      # uvicorn --reload
+```
 
-The entire code for the webapp can be found [here.](https://github.com/prateekralhan/Streamlit-based-Automatic-Number-Plate-Recognition)
+Run the end-to-end test against real bundled models (downloads ~30MB on first run):
 
+```bash
+ANPR_RUN_REAL=1 uv run pytest tests/integration/test_pipeline_real.py
+```
 
-## Source  
-- https://docs.python.org/3/library/csv.html  
-- https://github.com/ultralytics/yolov5  
-- https://github.com/PaddlePaddle/PaddleOCR
-- https://medium.com/move-on-ai/yolov5-object-detection-with-your-own-dataset-6e3823a8f66b  
-- https://github.com/JaidedAI/EasyOCR  
--     https://www.researchgate.net/publication/319198085_License_Number_Plate_Recognition_System_using_Entropy_basedFeatures_Selection_Approach_with_SVM/figures?lo=1&utm_source=google&utm_medium=organic
+---
 
-## Licence
-[MIT](https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/blob/main/LICENSE)
+## Project structure
 
-## To Do 
-- [ ] use fcaykon pip yolo instead of hardcoded yolo files
-- [ ] hugging face
+```
+src/anpr/
+├── api/                 FastAPI app, routes, templates, static
+│   ├── app.py
+│   ├── deps.py          lifespan-loaded singletons
+│   ├── middleware.py    request_id + Prometheus middleware
+│   └── routes/          health, infer, stream (WS), detections
+├── detector/            Detector Protocol + fast-alpr adapter
+├── ocr/                 PlateReader Protocol + fast-plate-ocr adapter
+├── postprocess/         turkish, confusion, temporal, dewarp
+├── storage/             SQLModel Detection + HMAC + repository + retention
+├── tracker/             IoU greedy tracker
+├── observability.py     Prometheus metrics + optional OTel
+├── config.py            pydantic-settings
+├── logging.py           structlog
+├── cli.py               typer
+└── pipeline.py          sync infer_image + async Pipeline
+tests/
+├── unit/                turkish, confusion, temporal, iou_tracker, hashing (+ hypothesis properties)
+└── integration/         pipeline_smoke, api_smoke, metrics, storage, infer_response_shape, pipeline_real
+legacy/                  2022 codebase preserved verbatim
+```
+
+---
+
+## Migration from the 2022 pipeline
+
+The 2022 code is **not** removed — it sits intact under [`legacy/`](legacy/). What changed:
+
+| 2022 | 2026 |
+|---|---|
+| Vendored YOLOv5 fork (~7900 LOC in `utils/` + `models/`) | `fast-alpr` 0.4 → YOLOv9-t-384 ONNX, MIT, ~150 LOC of glue |
+| EasyOCR 1.4 + PaddleOCR + Tesseract (mixed/inconsistent) | `fast-plate-ocr` 1.1 cct-s-v2 (single source of truth) |
+| Flask 1.1.2 (CVE) | FastAPI 0.115 + uvicorn |
+| `python main.py` (webcam) and `python app.py` (Flask, parallel + no OCR) | `anpr infer image.jpg`, `anpr serve` |
+| No tracking | IoU greedy + temporal majority voting |
+| No plate validation | Turkish format parser + confusion correction |
+| `requirements.txt` (broken: `tensorrt==0.0.1.dev5`, etc.) | `pyproject.toml` + `uv.lock` |
+| No tests, no CI | 60+ tests, GitHub Actions matrix |
+| `print()` | structlog + Prometheus + opt-in OTel |
+| CSV append, raw plate text | SQLModel + HMAC-SHA256 + retention worker |
+
+If you depended on the old import paths or the `model/best.pt` checkpoint, pin to the pre-merge tag and follow [`legacy/README.md`](legacy/) (yet to be written) for context.
+
+---
+
+## Acknowledgments
+
+This rewrite stands on the work of:
+
+- [`ankandrew/fast-alpr`](https://github.com/ankandrew/fast-alpr) — turn-key MIT-licensed ANPR pipeline
+- [`ankandrew/fast-plate-ocr`](https://github.com/ankandrew/fast-plate-ocr) — fast plate-specialized OCR with the `cct-s-v2-global-model`
+- [Ultralytics](https://github.com/ultralytics/ultralytics) — original YOLOv5 the 2022 pipeline built on
+- [Astral](https://astral.sh) — `uv` and `ruff`
+
+---
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

Follow-up to PR #16. Brings the project documentation up to date with the 2026 architecture and adds a starter KVKK notice for Turkish-jurisdiction deployments.

## README rewrite

The 2022 README walked through a workflow that no longer exists (`main.py` webcam loop, `app.py` Flask demo). The new README covers what's actually in `main`:

- CI / Python / license / ruff badges wired to the actual workflows
- Docker compose + native `uv` quickstart paths
- Full layer table (detector, OCR, tracker, parser, confusion fix, temporal voting, web, storage, observability)
- API endpoint reference table
- ASCII architecture diagram
- `ANPR_*` env var reference
- **Privacy section** explaining the KVKK + GDPR rationale and the HMAC-SHA256-only persistence design
- Development cheat-sheet (`make` targets, real-model test gating)
- Project structure
- Migration matrix from the 2022 stack (what changed, what's now where)
- Acknowledgments

## KVKK_AYDINLATMA_METNI.md

Starter Turkish-language Article 10 notice template covering:

- Veri sorumlusu identification placeholders
- Processed data categories (notes that plate text is HMAC-only, not raw)
- Processing purposes
- Hukuki sebep checklist (KVKK md. 5)
- Aktarım
- Retention (linked to `ANPR_RETENTION_HOURS`)
- KVKK md. 11 haklar
- Teknik / idari tedbirler

Marked clearly as a starting point ("**bu belge hukuki tavsiye değildir**") and not legal advice — deployments must adapt to their actual processing context.

## Test plan
- [ ] README renders correctly on the GitHub repo page
- [ ] No dead links (anchors, badges)
- [ ] Quickstart instructions are reproducible on a clean clone