### PR TITLE
feat(packaging): publish as anpr-pipeline on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Build sdist + wheel
+        run: uv build
+      - name: List artifacts
+        run: ls -lh dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/anpr-pipeline
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish via OIDC trusted publishing
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# anpr — Automatic Number Plate Recognition
+# anpr-pipeline — Automatic Number Plate Recognition
 
+[![PyPI](https://img.shields.io/pypi/v/anpr-pipeline.svg)](https://pypi.org/project/anpr-pipeline/)
 [![CI](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/actions/workflows/ci.yml/badge.svg)](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%E2%80%933.13-blue.svg)](pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -13,7 +14,16 @@ End-to-end license plate recognition: **plate detection → tracking → OCR →
 
 ## Quickstart
 
-### Docker (recommended)
+### Via PyPI
+
+```bash
+pip install anpr-pipeline
+export ANPR_PLATE_HMAC_PEPPER="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+anpr serve                          # FastAPI on http://localhost:8000
+anpr infer path/to/plate.jpg        # one-shot CLI
+```
+
+### Docker
 
 ```bash
 export ANPR_PLATE_HMAC_PEPPER="$(python -c 'import secrets; print(secrets.token_hex(32))')"
@@ -22,7 +32,7 @@ docker compose up --build
 
 Open <http://localhost:8000>.
 
-### Native, via `uv`
+### From source, via `uv`
 
 ```bash
 git clone https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "anpr"
-version = "0.2.0"
+name = "anpr-pipeline"
+version = "0.2.1"
 description = "Automatic Number Plate Recognition — 2026 modernized pipeline (fast-alpr + FastAPI)"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -57,8 +57,8 @@ otel = [
 anpr = "anpr.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR"
-Issues = "https://github.com/mftnakrsu/Automatic-number-plate-recognition-YOLO-OCR/issues"
+Homepage = "https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR"
+Issues = "https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/anpr"]


### PR DESCRIPTION
## Summary

First-time PyPI release setup. The distribution name on PyPI is `anpr-pipeline` (the bare `anpr` is already claimed on PyPI by a different project). The import name stays `anpr`, so user code is unaffected.

## Changes

- **pyproject.toml**: `name = "anpr-pipeline"`, `version = "0.2.0" → "0.2.1"`. Fixed the canonical URL (the repo path uses underscores, not hyphens — the auto-filled value was wrong).
- **`.github/workflows/publish.yml`**: new workflow. Builds sdist + wheel with `uv build`, then publishes to PyPI via OIDC trusted publishing on any `v*` tag push (or `workflow_dispatch`). The publish job references the `pypi` GitHub environment so PyPI can pin trust to it specifically.
- **README**: PyPI version badge + `pip install anpr-pipeline` quickstart at the top of the install section.

Local build verified:

```
Successfully built dist/anpr_pipeline-0.2.1.tar.gz
Successfully built dist/anpr_pipeline-0.2.1-py3-none-any.whl
```

Wheel metadata: `Name: anpr-pipeline`, `Version: 0.2.1`, `License-Expression: MIT`, top-level package `anpr/`.

## One-time PyPI setup (manual, on PyPI side)

Before tagging `v0.2.1`, the maintainer must add a *pending publisher* on PyPI (no API token required, no secret to rotate):

1. Visit <https://pypi.org/manage/account/publishing/>
2. Click **Add a new pending publisher**
3. Fill in:
   - PyPI Project Name: `anpr-pipeline`
   - Owner: `mftnakrsu`
   - Repository name: `Automatic_Number_Plate_Recognition_YOLO_OCR`
   - Workflow filename: `publish.yml`
   - Environment name: `pypi`
4. Save.

After this PR is merged and `git tag v0.2.1 && git push origin v0.2.1` is run, the workflow auto-publishes the package. Subsequent releases just need a version bump + tag.

## Test plan

- [ ] CI on this PR green
- [ ] After merge: `uv build` reproduces the same artifacts locally
- [ ] PyPI pending publisher configured on the maintainer's PyPI account
- [ ] Tag `v0.2.1` pushed → workflow run succeeds → package visible on <https://pypi.org/project/anpr-pipeline/>
- [ ] Fresh venv: `pip install anpr-pipeline` succeeds, `anpr --help` works, `anpr serve` boots the FastAPI app