### PR TITLE
fix(packaging): keep sdist under PyPI's 100MB limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "anpr-pipeline"
-version = "0.2.1"
+version = "0.2.2"
 description = "Automatic Number Plate Recognition — 2026 modernized pipeline (fast-alpr + FastAPI)"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -62,6 +62,15 @@ Issues = "https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_O
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/anpr"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/anpr",
+    "README.md",
+    "LICENSE",
+    "KVKK_AYDINLATMA_METNI.md",
+    ".env.example",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
The first PyPI publish attempt (#19 → tag v0.2.1) failed with:

> \`400 File too large. Limit for project 'anpr-pipeline' is 100 MB\`

Cause: hatchling's default sdist sweeps **everything** in the repo, so \`legacy/\` (which contains the two ~14 MB YOLOv5 checkpoints from the 2022 codebase, totaling ~150 MB) ended up inside the tarball.

## Fix

Add an explicit sdist include allow-list to \`pyproject.toml\`:

\`\`\`toml
[tool.hatch.build.targets.sdist]
include = [
    \"src/anpr\",
    \"README.md\",
    \"LICENSE\",
    \"KVKK_AYDINLATMA_METNI.md\",
    \".env.example\",
]
\`\`\`

The wheel was always fine — it only ever shipped the \`anpr/\` package via \`[tool.hatch.build.targets.wheel]\`.

## Sizes

| Artifact | Before | After |
|---|---|---|
| sdist | 123 MB ❌ | **36 KB** ✓ |
| wheel | 38 KB ✓ | **38 KB** ✓ |

## Version bump

\`0.2.1 → 0.2.2\`. PyPI reserves the version slot from a failed upload, so re-pushing v0.2.1 with new artifacts would conflict. Bumping is the clean path.

## Test plan

- [ ] CI on this PR green
- [ ] After merge: tag \`v0.2.2\`, publish workflow uploads to PyPI successfully
- [ ] Fresh \`pip install anpr-pipeline\` works