### PR TITLE
fix(version): query 'anpr-pipeline' (the distribution name) for __version__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "anpr-pipeline"
-version = "0.2.2"
+version = "0.2.3"
 description = "Automatic Number Plate Recognition — 2026 modernized pipeline (fast-alpr + FastAPI)"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/anpr/__init__.py
+++ b/src/anpr/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("anpr")
+    __version__ = version("anpr-pipeline")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 


### PR DESCRIPTION
Found in PyPI smoke testing of v0.2.2: `anpr version` reports `anpr 0.0.0+unknown` because `src/anpr/__init__.py` calls `importlib.metadata.version("anpr")`, but the distribution name on PyPI is `anpr-pipeline`.

```python
# before
__version__ = version("anpr")              # PackageNotFoundError on installed
# after
__version__ = version("anpr-pipeline")     # 0.2.3 ✓
```

Bumps to 0.2.3 so users get the right number.