### PR TITLE
chore: repo hygiene — health files, CodeQL, GHCR Docker publish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something doesn't work the way it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in
+        everything you can — concrete repro steps + traceback make the
+        difference between a 10-minute fix and a 3-day investigation.
+  - type: input
+    id: version
+    attributes:
+      label: anpr-pipeline version
+      description: Output of `anpr version` (or `pip show anpr-pipeline`).
+      placeholder: "0.2.3"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.13.1"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / arch
+      placeholder: "Ubuntu 24.04 x86_64 / macOS 14.6 arm64 / Docker"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install method
+      options:
+        - pip install anpr-pipeline
+        - docker compose
+        - uv sync from source
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Full traceback if applicable. Set ANPR_LOG_LEVEL=DEBUG if you can.
+      render: shell
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I'm on the latest released version (or HEAD).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security advisory
+    url: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/security/advisories/new
+    about: For security issues use a private advisory (see SECURITY.md).
+  - name: PyPI project page
+    url: https://pypi.org/project/anpr-pipeline/
+    about: Latest released version, install instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest a new capability or enhancement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What's currently missing or painful?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check (KVKK / GDPR)
+      description: Plates are personal data; new features must respect the existing hash-only persistence model.
+      options:
+        - label: My proposal doesn't require persisting raw plate text.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- 1-3 sentences: what does this PR change, and why? -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no behavior change)
+- [ ] Docs
+- [ ] CI / build
+- [ ] Test only
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+- [ ] `make lint` clean
+- [ ] `make type` clean
+- [ ] `make test` green
+- [ ] (if API changed) manual smoke against `anpr serve` / `/api/v1/infer`
+
+## Related
+
+<!-- Issues, prior PRs, RFCs -->
+
+## Privacy / KVKK check
+
+- [ ] No code path persists raw plate text (only `hash_plate(...)` output).
+- [ ] N/A — this PR doesn't touch storage.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "32 4 * * 1" # Monday 04:32 UTC
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build distribution
+  build-python:
+    name: Build Python distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: build
+    needs: build-python
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     environment:
@@ -43,3 +43,43 @@ jobs:
           path: dist/
       - name: Publish via OIDC trusted publishing
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-docker:
+    name: Publish Docker image to GHCR
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata + tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/anpr-pipeline
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=anpr-pipeline
+            org.opencontainers.image.description=Automatic Number Plate Recognition pipeline (fast-alpr + fast-plate-ocr + FastAPI)
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes are documented here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+## [0.2.3] — 2026-05-10
+
+### Fixed
+
+- `anpr.__version__` was returning `0.0.0+unknown` for installed users — the
+  package queried `importlib.metadata.version("anpr")` while the distribution
+  name on PyPI is `anpr-pipeline`. Now correctly reports the installed
+  version. ([#25](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/25))
+
+## [0.2.2] — 2026-05-10
+
+### Fixed
+
+- Source distribution size: hatchling's default file sweep was including the
+  150MB `legacy/` tree, blowing past PyPI's 100MB project limit. An explicit
+  `[tool.hatch.build.targets.sdist].include` allow-list now produces a 36 KB
+  sdist. ([#24](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/24))
+
+## [0.2.1] — 2026-05-10 [YANKED]
+
+First PyPI publish attempt. The sdist exceeded PyPI's size limit; only the
+wheel uploaded before the sdist upload failed. Yanked — use 0.2.2+.
+
+### Added
+
+- Distribution renamed `anpr` → `anpr-pipeline` (the import name remains
+  `anpr`).
+- GitHub Actions publish workflow via OIDC trusted publishing.
+- README PyPI badge + `pip install anpr-pipeline` quickstart. ([#19](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/19))
+
+## [0.2.0] — 2026-05-10
+
+Initial release of the 2026 modernization. Full rewrite of the 2022 YOLOv5 +
+EasyOCR + Flask 1.1 pipeline. The original code is preserved verbatim under
+[`legacy/`](legacy/) and tagged [`v0.1.0-legacy`](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/releases/tag/v0.1.0-legacy).
+
+### Added
+
+- `fast-alpr` 0.4 / YOLOv9-t-384 ONNX plate detector (MIT, 65+ countries).
+- `fast-plate-ocr` 1.1 / `cct-s-v2-global-model` OCR (MIT, sub-millisecond GPU
+  with per-character confidences).
+- Dependency-free IoU greedy tracker (`Tracker` Protocol allows swap to
+  ByteTrack / BoT-SORT).
+- Position-aware OCR confusion-pair correction (0/O, 1/I/L, 5/S, 8/B, 2/Z,
+  6/G, 0/D/Q) keyed on the Turkish plate format.
+- Per-track temporal majority voting (top-K confidence-weighted, per-character
+  position).
+- Turkish-plate parser covering all 81 province codes.
+- FastAPI 0.115 + uvicorn HTTP/WebSocket API with async streaming pipeline,
+  bounded queue + drop-on-full backpressure.
+- SQLModel storage with HMAC-SHA256 plate hashing (KVKK + GDPR aware; raw
+  plate text is never persisted). Background retention worker.
+- `structlog` + Prometheus `/metrics` + opt-in OpenTelemetry instrumentation.
+- Multi-stage Dockerfile + `docker-compose.yml`.
+- GitHub Actions CI: matrix on Python 3.11 / 3.12 / 3.13 + ruff + pyright +
+  pytest + Docker smoke.
+- 60+ tests (unit + integration + Hypothesis property tests).
+- `pydantic-settings`-driven config (`.env` + `ANPR_*` env vars).
+- typer CLI: `anpr serve | infer | dump-config | generate-pepper | version`.
+- Modernized README + KVKK Aydınlatma Metni şablonu.
+
+### Removed
+
+- Vendored YOLOv5 fork (~7900 LOC under `utils/` + `models/`).
+- EasyOCR 1.4 + PaddleOCR + Tesseract triple-OCR layer.
+- Flask 1.1.2 + Werkzeug stack (CVE-laden).
+- `helper/params.py` ≡ `utils/params.py` byte-identical duplicates.
+- Hardcoded `/home/mef/Documents/plate_detection_project/best.pt`.
+- CSV plate-text persistence (replaced by hashed SQLite via SQLModel).
+
+### Migration
+
+- Entry points changed: `python main.py` → `anpr serve`; `python app.py`
+  removed in favor of the FastAPI app.
+- Pinning to the 2022 pipeline: `git checkout v0.1.0-legacy`.
+
+### Merged in this release
+
+- [#16](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/16) — F0–F7 (scaffold + pipeline + API + storage + tests)
+- [#17](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/17) — F8 (Docker + CI matrix)
+- [#18](https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/pull/18) — F9 (README + KVKK template)
+
+[Unreleased]: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/releases/tag/v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing
+
+Contributions are welcome — bug reports, fixes, features, docs improvements.
+
+## Quick start
+
+```bash
+git clone https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR.git
+cd Automatic_Number_Plate_Recognition_YOLO_OCR
+uv sync --all-extras --group dev
+make test
+```
+
+## Workflow
+
+1. Open an issue first for non-trivial changes so we agree on scope.
+2. Fork the repo, then branch off `main`. Branch naming:
+   - `feat/...` for features
+   - `fix/...` for bugs
+   - `docs/...` for documentation
+   - `chore/...` / `ci/...` / `test/...` / `refactor/...` as appropriate
+3. Keep PRs focused — one logical change per PR.
+4. Use [conventional-commits](https://www.conventionalcommits.org/) prefixes
+   in your commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `ci:`,
+   `refactor:`.
+5. Make sure CI passes (see below).
+
+## Pre-merge checks
+
+CI runs `ruff`, `pyright`, `pytest` on Python 3.11 / 3.12 / 3.13 + a Docker
+smoke test on every PR. To run the same checks locally:
+
+```bash
+make lint       # ruff check + ruff format --check
+make type       # pyright
+make test       # pytest (60+ tests)
+```
+
+`pre-commit` hooks are configured — opt in with:
+
+```bash
+uv run pre-commit install
+```
+
+## Testing
+
+- Unit tests live in `tests/unit/`.
+- Integration tests in `tests/integration/`.
+- Tests using the real `fast-alpr` / `fast-plate-ocr` models are gated behind
+  `ANPR_RUN_REAL=1` so the default suite is fast and offline.
+
+## Code style
+
+- Python 3.11+ (3.13 preferred for local dev).
+- Formatted by `ruff format` (Black-compatible, 100-col line length).
+- Type-checked by `pyright` (`standard` mode).
+- Public functions need full type hints.
+- New modules should use `from __future__ import annotations`.
+
+## Privacy by design (KVKK / GDPR)
+
+This is an ANPR project — license plates are personal data under KVKK
+(Law 6698) and the EU GDPR. New features must respect the existing model:
+
+- Don't add code paths that persist **raw plate text** to durable storage.
+- New API responses returning plate text should be auth-gated or documented
+  as in-memory only.
+- Persistence operations must continue to use `hash_plate(plate, pepper)`
+  from `src/anpr/storage/hashing.py`.
+
+## Reporting security issues
+
+**Don't** open public issues for security vulnerabilities — see
+[`SECURITY.md`](SECURITY.md) for the disclosure process.
+
+## Releasing
+
+(Maintainers only.)
+
+1. Bump `version` in `pyproject.toml` and add a section to `CHANGELOG.md`.
+2. Open a "release: vX.Y.Z" PR.
+3. After merge, tag from `main`:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+4. The `Publish` workflow auto-builds + pushes to PyPI (via OIDC trusted
+   publishing) and the Docker image to GHCR.
+5. Create a GitHub Release pointing at the new tag with summarized notes.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Be kind. Personal attacks, harassment, and discrimination aren't welcome.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| 0.2.x | ✅ |
+| < 0.2.0 (legacy 2022 stack) | ❌ |
+
+The `v0.1.0-legacy` tag is preserved verbatim under [`legacy/`](legacy/) for
+historical reference. It is not maintained; CVEs in those packages will not
+receive patches here. Use the modernized pipeline (`pip install anpr-pipeline`).
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security problems.**
+
+### Preferred — GitHub Private Security Advisory
+
+<https://github.com/mftnakrsu/Automatic_Number_Plate_Recognition_YOLO_OCR/security/advisories/new>
+
+### Alternative — Email
+
+<meftunakrsu@gmail.com> — include `[ANPR-SECURITY]` in the subject. PGP key
+available on request.
+
+## Response Timeline
+
+- **Acknowledgement**: within 7 days
+- **Triage + fix plan**: within 14 days
+- **Patched release on PyPI**: as fast as the severity warrants
+
+## Disclosure
+
+After a patched release is on PyPI we will publish a GitHub Security Advisory
+and credit the reporter (unless anonymity is requested).
+
+## Out of Scope
+
+- The archived `legacy/` codebase — historical reference only, not maintained.
+- Issues that require the attacker to already control the deployment
+  environment (e.g., a leaked `ANPR_PLATE_HMAC_PEPPER`, root on the host).
+- Vulnerabilities in transitive dependencies — please report directly to the
+  upstream maintainer (`fast-alpr`, `fast-plate-ocr`, `fastapi`, etc.). We
+  receive Dependabot alerts and will bump when patches land upstream.
+
+## Hardening Notes for Operators
+
+If you are deploying this in production:
+
+- **Set a strong `ANPR_PLATE_HMAC_PEPPER`** (≥ 32 hex chars from `anpr
+  generate-pepper`). Don't reuse across deployments.
+- Restrict `ANPR_CORS_ORIGINS` to your actual frontend origins; never leave
+  it as `*` in production.
+- Front the FastAPI app with a TLS-terminating reverse proxy (Caddy, nginx,
+  Cloudflare).
+- Tune `ANPR_RETENTION_HOURS` to your retention policy. The default (720h /
+  30d) is a hobby default, not a legal recommendation.
+- Run behind authentication for the `/api/v1/detections` endpoint if it
+  matters to your threat model — the bundled app exposes it unauthenticated.


### PR DESCRIPTION
Polishes the repo to standard OSS health-file expectations and closes a distribution gap.

## Health files

- **SECURITY.md** — supported-versions table, GitHub private advisory + email disclosure paths, response timeline, plus hardening notes for operators (CORS lockdown, retention policy, pepper rotation).
- **CHANGELOG.md** — Keep-a-Changelog format; v0.2.0 release + v0.2.1 (yanked) / v0.2.2 / v0.2.3 patch sections populated with PR backrefs.
- **CONTRIBUTING.md** — onboarding (clone + `uv sync` + `make test`), branch naming, conventional-commit prefixes, KVKK/GDPR design rules ("don't persist raw plate text"), release procedure for maintainers.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML form, enforces version + python + repro fields.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — incl. a KVKK privacy-impact checkbox.
- **`.github/ISSUE_TEMPLATE/config.yml`** — directs security issues to the private advisory; links to PyPI.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — type-of-change checklist + test plan + KVKK check.

## Workflows

- **`.github/workflows/codeql.yml`** — free Python security/quality scan on push, PR, and weekly (Mon 04:32 UTC).
- **`.github/workflows/publish.yml`** — extended with a `publish-docker` job. On every tag push, the existing PyPI publish now runs alongside a Docker publish to `ghcr.io/mftnakrsu/anpr-pipeline` (semver `{version}` + `{major}.{minor}` + `latest` tags) via `docker/metadata-action` + `docker/build-push-action` with GHA layer cache. Opt-in manual run via `workflow_dispatch`.

## Out of scope

- README `docker pull ghcr.io/...` instructions — will come in a follow-up after the first tag triggers the GHCR job and the image is live.